### PR TITLE
simplify if statement.

### DIFF
--- a/src/memoize/main.go
+++ b/src/memoize/main.go
@@ -32,7 +32,7 @@ func Memoize(key string, caller func() interface{}, timeout uint) interface{} {
 	memoized := mp.Pool[key]
 	mp.mutex.RUnlock()
 	// reached timeout or not memoized
-	if (memoized != nil && memoized.Timeout.Before(time.Now())) || memoized == nil {
+	if memoized == nil || memoized.Timeout.Before(time.Now()) {
 		result := caller()
 		if result != nil {
 			duration := time.Duration(timeout) * time.Second

--- a/src/memoize/main.go
+++ b/src/memoize/main.go
@@ -7,11 +7,11 @@ import (
 
 type memo struct {
 	Timeout time.Time
-	Result interface{}
+	Result  interface{}
 }
 
 type MemoPool struct {
-	Pool map[string]*memo
+	Pool  map[string]*memo
 	mutex *sync.RWMutex
 }
 
@@ -39,7 +39,7 @@ func Memoize(key string, caller func() interface{}, timeout uint) interface{} {
 			mp.mutex.Lock()
 			mp.Pool[key] = &memo{
 				Timeout: time.Now().Add(duration),
-				Result: result,
+				Result:  result,
 			}
 			mp.mutex.Unlock()
 		}


### PR DESCRIPTION
If the first part of a logical OR `||` is `true` the second part will never be executed. Therefore the if statement can be simplified.
